### PR TITLE
Remove the nixpkgs override from the README as it is no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ In your NixOS configuration directory:
   # Add base16.nix, base16 schemes and
   # zathura and vim templates to the flake inputs.
   base16.url = github:SenchoPens/base16.nix;
-  base16.inputs.nixpkgs.follows = "nixpkgs";
 
   base16-schemes = {
     url = github:base16-project/base16-schemes;


### PR DESCRIPTION
Before that, when rebuilding or checking, this warning appeared with the config from the README: `warning: input 'base16' has an override for a non-existent input 'nixpkgs'`