### PR TITLE
Add mnemonics for base12-base17

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -33,7 +33,7 @@ returns a _scheme attrset_ with a ton of convenient color attributes:
 - every attribute from [the base16 standard](https://github.com/base16-project/base16/blob/main/builder.md#template-variables),
 - attributes `baseXX = baseXX-hex`, e.g. `base00 = "000000"`;
 - `toList = [ base00 ... base0F ]`, for use in e.g. `config.console.colors`,
-- mnemonic color names for `base08` — `base0F`:
+- mnemonic color names for `base08` — `base0F` and `base12` — `base17`:
   ```nix
   mnemonic = {
     red = base08;
@@ -44,6 +44,12 @@ returns a _scheme attrset_ with a ton of convenient color attributes:
     blue = base0D;
     magenta = base0E;
     brown = base0F;
+    bright-red = base12 or base08;
+    bright-orange = base13 or base09;
+    bright-green = base14 or base0B;
+    bright-cyan = base15 or base0C;
+    bright-blue = base16 or base0D;
+    bright-magenta = base17 or base0E;
   };
   ```
 

--- a/lib/colors.nix
+++ b/lib/colors.nix
@@ -26,7 +26,7 @@ let
     base10 = scheme.base10 or scheme.base00;
     base11 = scheme.base11 or scheme.base00;
     base12 = scheme.base12 or scheme.base08;
-    base13 = scheme.base13 or scheme.base0A;
+    base13 = scheme.base13 or scheme.base09;
     base14 = scheme.base14 or scheme.base0B;
     base15 = scheme.base15 or scheme.base0C;
     base16 = scheme.base16 or scheme.base0D;

--- a/lib/colors.nix
+++ b/lib/colors.nix
@@ -38,7 +38,8 @@ let
 
      For convenience, attributes of the form `baseXX` are provided, which are equal to
      `baseXX-hex`, along with a `toList` attribute, which is equal to `[ base00 ... base0F ]`
-     (mainly for config.console.colors).  Also, mnemonic color names for base08-base0F are provided:
+     (mainly for config.console.colors).  Also, mnemonic color names for base08-base0F and 
+     base12-base17 are provided:
      ```
       mnemonic = {
         red = base08;
@@ -49,6 +50,12 @@ let
         blue = base0D;
         magenta = base0E;
         brown = base0F;
+        bright-red = base12 or base08;
+        bright-orange = base13 or base09;
+        bright-green = base14 or base0B;
+        bright-cyan = base15 or base0C;
+        bright-blue = base16 or base0D;
+        bright-magenta = base17 or base0E;
       };
       ```
   */
@@ -91,6 +98,12 @@ let
         blue = base0D;
         magenta = base0E;
         brown = base0F;
+        bright-red = base-short.base12 or base08;
+        bright-orange = base-short.base13 or base09;
+        bright-green = base-short.base14 or base0B;
+        bright-cyan = base-short.base15 or base0C;
+        bright-blue = base-short.base16 or base0D;
+        bright-magenta = base-short.base17 or base0E;
       };
 
       base-hex-bgr = lib.mapAttrs' (k: v:


### PR DESCRIPTION
Specification for the brighter colors can be found here: https://github.com/tinted-theming/base24/blob/master/styling.md

Also included a small fix for the base24 aliases.