### PR TITLE
Fix slugify

### DIFF
--- a/lib/util.nix
+++ b/lib/util.nix
@@ -58,8 +58,8 @@ let
     (raw.palette or {})
     // {
       scheme = raw.name or "untitled";
-      slug = raw.slug or (slugify raw.name);
-    } 
+      slug = raw.slug or (slugify (raw.name or "untitled"));
+    }
     // (removeAttrs raw [ "palette" ]);
 
   /* Normalizes a scheme attrset's colors:


### PR DESCRIPTION
This shows up in issue #18. Slugify wasn't given a default scheme name. This fixes that by giving it the same default scheme name of "untitled"