### PR TITLE
mk-theme: make $out the file

### DIFF
--- a/lib/mk-theme.nix
+++ b/lib/mk-theme.nix
@@ -76,9 +76,10 @@ let
         else
           writeTextFile'' "${target}.mustache" template  # escaped
         ;
+    in 
       # Taken from https://pablo.tools/blog/computers/nix-mustache-templates/
-      themeDerivation = pkgs.stdenv.mkDerivation {
-        name = "${builtins.unsafeDiscardStringContext scheme.scheme-slug}";
+      pkgs.stdenv.mkDerivation {
+        name = themeFilename;
         allowSubstitutes = false;
         preferLocalBuild = true;
         nativeBuildInputs = [ pkgs.mustache-go ]
@@ -93,9 +94,7 @@ let
           mustache "$jsonDataPath" ${templatePath} > theme
         '';
         installPhase = ''
-          mkdir $out
-          cp theme $out/${lib.escapeShellArg themeFilename}
+          cp theme $out
         '';
       };
-    in "${themeDerivation}/${themeFilename}";
 in { inherit mkTheme; }


### PR DESCRIPTION
doesn't make such sense to have a $out with one file in it, it would be better to just have $out be the file. An upside of this is that `lib.isStorePath` now returns true for the output of mk-theme, which we need downstream in stylix (see https://github.com/danth/stylix/pull/1164). 