### PR TITLE
Fix non-conformant `base13` color

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -45,7 +45,7 @@ returns a _scheme attrset_ with a ton of convenient color attributes:
     magenta = base0E;
     brown = base0F;
     bright-red = base12 or base08;
-    bright-orange = base13 or base09;
+    bright-yellow = base13 or base0A;
     bright-green = base14 or base0B;
     bright-cyan = base15 or base0C;
     bright-blue = base16 or base0D;

--- a/lib/colors.nix
+++ b/lib/colors.nix
@@ -26,7 +26,7 @@ let
     base10 = scheme.base10 or scheme.base00;
     base11 = scheme.base11 or scheme.base00;
     base12 = scheme.base12 or scheme.base08;
-    base13 = scheme.base13 or scheme.base09;
+    base13 = scheme.base13 or scheme.base0A;
     base14 = scheme.base14 or scheme.base0B;
     base15 = scheme.base15 or scheme.base0C;
     base16 = scheme.base16 or scheme.base0D;
@@ -51,7 +51,7 @@ let
         magenta = base0E;
         brown = base0F;
         bright-red = base12 or base08;
-        bright-orange = base13 or base09;
+        bright-yellow = base13 or base0A;
         bright-green = base14 or base0B;
         bright-cyan = base15 or base0C;
         bright-blue = base16 or base0D;
@@ -99,7 +99,7 @@ let
         magenta = base0E;
         brown = base0F;
         bright-red = base-short.base12 or base08;
-        bright-orange = base-short.base13 or base09;
+        bright-yellow = base-short.base13 or base0A;
         bright-green = base-short.base14 or base0B;
         bright-cyan = base-short.base15 or base0C;
         bright-blue = base-short.base16 or base0D;


### PR DESCRIPTION
`base13` is supposed to be the brighter version of `base0A` (yellow), not `base09` (orange).

From the [upstream specification](https://github.com/tinted-theming/base24/blob/main/styling.md):

> We provide a mapping between Base24 and Base16 colour codes for
> reference:
> 
> | Base24 | Base16 |
> | ------ | ------ |
> | … | … |
> | base13 | base0A |

> | Colour | BaseNN | Ansi | Terminal/Colour Use | Text Editor |
> | - | ------ | ---- | ------------------- | ----------- |
> | … | … | … | … | … |
> | ![Colour](https://placehold.co/25/efb074/000000?text=%2B) | base13 | 11   | Bright Yellow       | NA |

This PR fixes the definition accordingly.